### PR TITLE
Add XL_PATH variable

### DIFF
--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -126,13 +126,10 @@ class Program
         string? useAltPath = Environment.GetEnvironmentVariable("XL_PATH");
         try 
         {
-            // Try using the XL_PATH environment variable.
             storage = new Storage(APP_NAME, useAltPath);
         }
         catch (Exception e)
         {
-            // If it's somehow bad or we don't have permissions, just ignore it.
-            // Unfortunately, we can't log this easily, so here's a hacky workaround.
             storage = new Storage(APP_NAME);
             badxlpath = true;
             badxlpathex = e;
@@ -142,7 +139,7 @@ class Program
 
         if (badxlpath)
         {
-            Log.Error(badxlpathex, $"Bad value for XL_PATH={useAltPath}");
+            Log.Error(badxlpathex, $"Bad value for XL_PATH: {useAltPath}. Using ~/.xlcore instead.");
         }
 
         Secrets = GetSecretProvider(storage);

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -121,7 +121,8 @@ class Program
 
     private static void Main(string[] args)
     {
-        storage = new Storage(APP_NAME);
+        string? useAltPath = Environment.GetEnvironmentVariable("XL_PATH");
+        storage = new Storage(APP_NAME, useAltPath);
         SetupLogging(args);
         LoadConfig(storage);
 

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -124,7 +124,7 @@ class Program
         string? useAltPath = Environment.GetEnvironmentVariable("XL_PATH");
         try
         {
-            useAltPath = Path.GetFullPath("useAltPath");
+            Path.GetFullPath(useAltPath);
         }
         catch (Exception e)
         {

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -122,6 +122,14 @@ class Program
     private static void Main(string[] args)
     {
         string? useAltPath = Environment.GetEnvironmentVariable("XL_PATH");
+        try
+        {
+            useAltPath = Path.GetFullPath("useAltPath");
+        }
+        catch (Exception e)
+        {
+            useAltPath = null;
+        }
         storage = new Storage(APP_NAME, useAltPath);
         SetupLogging(args);
         LoadConfig(storage);

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -121,18 +121,29 @@ class Program
 
     private static void Main(string[] args)
     {
+        bool badxlpath = false;
+        var badxlpathex = new Exception();
         string? useAltPath = Environment.GetEnvironmentVariable("XL_PATH");
-        try
+        try 
         {
-            Path.GetFullPath(useAltPath);
+            // Try using the XL_PATH environment variable.
+            storage = new Storage(APP_NAME, useAltPath);
         }
         catch (Exception e)
         {
-            useAltPath = null;
+            // If it's somehow bad or we don't have permissions, just ignore it.
+            // Unfortunately, we can't log this easily, so here's a hacky workaround.
+            storage = new Storage(APP_NAME);
+            badxlpath = true;
+            badxlpathex = e;
         }
-        storage = new Storage(APP_NAME, useAltPath);
         SetupLogging(args);
         LoadConfig(storage);
+
+        if (badxlpath)
+        {
+            Log.Error(badxlpathex, $"Bad value for XL_PATH={useAltPath}");
+        }
 
         Secrets = GetSecretProvider(storage);
 


### PR DESCRIPTION
Allow the user to set an alternate path for xlcore directory. For example, `XL_PATH=$HOME/.local/share/xlcore` 