### PR TITLE
Add MangoHud

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsEntry{T}.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsEntry{T}.cs
@@ -80,8 +80,10 @@ public class SettingsEntry<T> : SettingsEntry
             if (ImGui.BeginCombo($"###{Id.ToString()}", descriptions[idx].FriendlyName))
             {
                 foreach (int value in values)
-                {
-                    if (ImGui.Selectable(descriptions[value].FriendlyName, idx == value))
+                {   
+                    string desc = descriptions[value].Description;
+                    desc = (desc == string.Empty || desc == "dummy") ? string.Empty : " - " + desc;
+                    if (ImGui.Selectable(descriptions[value].FriendlyName + desc, idx == value))
                     {
                         this.InternalValue = value;
                     }

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -51,7 +51,7 @@ public class SettingsTabWine : SettingsTab
                 }
             },
 
-            new SettingsEntry<Dxvk.DxvkHudType>("DXVK Overlay", "Configure how much of the DXVK overlay is to be shown.", () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type),
+            new SettingsEntry<Dxvk.DxvkHudType>("DXVK Overlay", "DXVK Hud (available) or MangoHud (only works if installed)", () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type),
             new SettingsEntry<string>("WINEDEBUG Variables", "Configure debug logging for wine. Useful for troubleshooting.", () => Program.Config.WineDebugVars ?? string.Empty, s => Program.Config.WineDebugVars = s)
         };
     }


### PR DESCRIPTION
Tweaked DXVK Hud text to show MangoHud compatibility.

Also expanded descriptions in dropdown menus. The menu entries now show the SettingsDescriptionAttribute FriendlyName - Description, instead of just FriendlyName. If description is empty or "dummy", it's left off.