### PR TITLE
Add Nix Flake distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,6 @@ XIVLauncher-RB is not officially supported by the XIVLauncher community, but man
 | [AUR](https://aur.archlinux.org/packages/xivlauncher-rb) | ![AUR version](https://img.shields.io/aur/version/xivlauncher-rb) |
 | [Copr (Fedora+openSuse+EL9)](https://copr.fedorainfracloud.org/coprs/rankyn/xivlauncher/) | ![COPR version](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frankynbass%2FXIVLauncher4rpm%2FRB-patched%2Fbadge.json)|
 | [MPR (Debian+Ubuntu)](https://mpr.makedeb.org/packages/xivlauncher-rb)  | ![MPR package](https://repology.org/badge/version-for-repo/mpr/xivlauncher-rb.svg?header=MPR) |
+| [Nix Flake](https://github.com/drakon64/nixos-xivlauncher-rb) | [![Update](https://github.com/drakon64/nixos-xivlauncher-rb/actions/workflows/xivlauncher-rb.yml/badge.svg?event=schedule)](https://github.com/drakon64/nixos-xivlauncher-rb/actions/workflows/xivlauncher-rb.yml) |
 
 If there are any others, please let me know and I'll add them.


### PR DESCRIPTION
I've packaged XIVLauncher-RB as a Nix Flake for NixOS users to install it with.

The badge displays the last attempt at updating the package to the latest XIVLauncher-RB version. This show as successful if the package is already at the latest version.