### PR TITLE
chore: xlm download url change

### DIFF
--- a/xlm/install-flatpak.sh
+++ b/xlm/install-flatpak.sh
@@ -4,7 +4,7 @@ echo "-- XLM Flatpak Auto-Installer --"
 echo ""
 
 echo "[Step: 1] Downloading XLM"
-curl -L https://github.com/Blooym/xlm/releases/latest/download/xlm > /tmp/xlm
+curl -L https://github.com/Blooym/xlm/releases/latest/download/xlm-x86_64-unknown-linux-gnu  > /tmp/xlm
 
 echo "[Step: 2] Configuring XLM as a Steam Tool"
 chmod +x /tmp/xlm

--- a/xlm/install-native.sh
+++ b/xlm/install-native.sh
@@ -4,7 +4,7 @@ echo "-- XLM Native Auto-Installer --"
 echo ""
 
 echo "[Step: 1] Downloading XLM"
-curl -L https://github.com/Blooym/xlm/releases/latest/download/xlm > /tmp/xlm
+curl -L https://github.com/Blooym/xlm/releases/latest/download/xlm-x86_64-unknown-linux-gnu > /tmp/xlm
 
 echo "[Step: 2] Configuring XLM as a Steam Tool using XIVLauncher-RB"
 chmod +x /tmp/xlm

--- a/xlm/install-snap.sh
+++ b/xlm/install-snap.sh
@@ -4,7 +4,7 @@ echo "-- XLM Snap Auto-Installer --"
 echo ""
 
 echo "[Step: 1] Downloading XLM"
-curl -L https://github.com/Blooym/xlm/releases/latest/download/xlm > /tmp/xlm
+curl -L https://github.com/Blooym/xlm/releases/latest/download/xlm-x86_64-unknown-linux-gnu > /tmp/xlm
 
 echo "[Step: 2] Configuring XLM as a Steam Tool"
 chmod +x /tmp/xlm

--- a/xlm/install-steamdeck.sh
+++ b/xlm/install-steamdeck.sh
@@ -4,7 +4,7 @@ echo "-- XLM Steam Deck Auto-Installer --"
 echo ""
 
 echo "[Step: 1] Downloading XLM"
-curl -L https://github.com/Blooym/xlm/releases/latest/download/xlm > /tmp/xlm
+curl -L https://github.com/Blooym/xlm/releases/latest/download/xlm-x86_64-unknown-linux-gnu > /tmp/xlm
 
 echo "[Step: 2] Configuring XLM as a Steam Tool using XIVLauncher-RB"
 chmod +x /tmp/xlm


### PR DESCRIPTION
I'm keeping compatibility by duplicating assets for current releases but the xlm auto updater required me to rename the release asset so I'm updating your scripts to make sure they work too